### PR TITLE
Add require-auth Cargo feature flag to make authentication optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
 
+[features]
+default = ["require-auth"]
+require-auth = []
+
 [package]
 name = "foody"
 version = "0.1.0"

--- a/docs/optional-auth-feature-flag.md
+++ b/docs/optional-auth-feature-flag.md
@@ -1,0 +1,223 @@
+# Optional Auth: `require-auth` Cargo Feature Flag
+
+## Core Idea
+
+Rather than `#[cfg]` on individual function parameters (which Rust doesn't support), we introduce a single `MaybeAuth` extractor type in a new `src/auth_gate.rs` file. When `require-auth` is enabled (the default), it delegates to `auth::JWT` and behaves identically to today. When disabled, it succeeds unconditionally with a placeholder identity. Every handler changes `auth: auth::JWT` → `auth: MaybeAuth` — one mechanical find/replace — and **no handler bodies need to change**.
+
+Build without auth: `cargo build --no-default-features`
+
+---
+
+## Step 1 — `Cargo.toml`: Add the feature
+
+```toml
+[features]
+default = ["require-auth"]
+require-auth = []
+```
+
+---
+
+## Step 2 — New file `src/auth_gate.rs`: The `MaybeAuth` extractor
+
+Two `impl FromRequestParts` blocks gated by `#[cfg(feature = "require-auth")]` / `#[cfg(not(...))]`. The no-auth branch returns a dummy `UserClaims` with a fixed anonymous PID (`00000000-0000-0000-0000-000000000000`). Check the exact `UserClaims` fields from the loco-rs source before implementing.
+
+```rust
+// src/auth_gate.rs
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use loco_rs::{app::AppContext, controller::extractor::auth, errors::Error};
+use axum::extract::FromRef;
+
+pub const ANONYMOUS_PID: &str = "00000000-0000-0000-0000-000000000000";
+
+#[derive(Debug)]
+pub struct MaybeAuth {
+    pub claims: auth::jwt::UserClaims,
+}
+
+#[cfg(feature = "require-auth")]
+impl<S> FromRequestParts<S> for MaybeAuth
+where
+    AppContext: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Error> {
+        let jwt = auth::JWT::from_request_parts(parts, state).await?;
+        Ok(Self { claims: jwt.claims })
+    }
+}
+
+#[cfg(not(feature = "require-auth"))]
+impl<S> FromRequestParts<S> for MaybeAuth
+where
+    AppContext: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(_parts: &mut Parts, _state: &S) -> Result<Self, Error> {
+        Ok(Self {
+            claims: auth::jwt::UserClaims {
+                pid: ANONYMOUS_PID.to_string(),
+                // fill remaining fields — check loco-rs source for full struct definition
+            },
+        })
+    }
+}
+```
+
+Expose it via `pub mod auth_gate;` in `src/lib.rs`.
+
+---
+
+## Step 3 — Mechanical replacement in 7 controller files
+
+Add `use crate::auth_gate::MaybeAuth;` and replace all 41 occurrences of `auth: auth::JWT` / `_auth: auth::JWT` with `auth: MaybeAuth`.
+
+| File | Occurrences |
+|---|---|
+| `src/controllers/shoppinglists.rs` | 15 |
+| `src/controllers/recipes.rs` | 8 |
+| `src/controllers/mealplans.rs` | 9 |
+| `src/controllers/ingredients.rs` | 5 |
+| `src/controllers/ailes.rs` | 2 |
+| `src/controllers/storage.rs` | 1 |
+| `src/controllers/graphql.rs` | 1 (special case, see Step 5) |
+
+Handler bodies require **zero changes** — `auth.claims.pid` works identically on `MaybeAuth`.
+
+---
+
+## Step 4 — `src/app.rs`: Gate auth + user routes
+
+```rust
+fn routes(_ctx: &AppContext) -> AppRoutes {
+    let mut routes = AppRoutes::with_default_routes()
+        .add_route(controllers::recipes::routes())
+        .add_route(controllers::ingredients::routes())
+        .add_route(controllers::shoppinglists::routes())
+        .add_route(controllers::mealplans::routes())
+        .add_route(controllers::ailes::routes())
+        .add_route(controllers::storage::routes())
+        .add_route(controllers::graphql::routes());
+
+    #[cfg(feature = "require-auth")]
+    {
+        routes = routes
+            .add_route(controllers::auth::routes())   // POST /api/auth/login
+            .add_route(controllers::user::routes());  // GET /api/user/current
+    }
+
+    routes
+}
+```
+
+`auth.rs` and `user.rs` need no changes — they just won't be routed when auth is disabled.
+
+---
+
+## Step 5 — Seed an anonymous user (for no-auth mode)
+
+All handlers call `users::Model::find_by_pid(&ctx.db, &auth.claims.pid)`. With auth disabled, `claims.pid` will be `ANONYMOUS_PID`. A matching user row must exist in the database.
+
+Seed one static user with `pid = ANONYMOUS_PID`. This is harmless in auth mode since no real JWT would ever carry that PID.
+
+This also handles `graphql.rs`, which is the one handler that actually *uses* the resolved user (passes it into the GraphQL schema context as `.data(user)`).
+
+---
+
+## Step 6 — Tests: one change to `prepare_data.rs`
+
+Make `authenticated()` a no-op when the feature is off — all tests that call it continue to work unchanged:
+
+```rust
+pub async fn authenticated(request: &mut TestServer, ctx: &AppContext) {
+    #[cfg(feature = "require-auth")]
+    {
+        let logged_in_user = init_user_login(request, ctx).await;
+        let (auth_key, auth_value) = auth_header(&logged_in_user.token);
+        request.add_header(auth_key, auth_value);
+    }
+}
+```
+
+Also gate the `can_get_current_user` test in `tests/requests/user.rs` since the route won't be registered:
+
+```rust
+#[cfg(feature = "require-auth")]
+#[tokio::test]
+#[serial]
+async fn can_get_current_user() { ... }
+```
+
+---
+
+## Step 7 — Frontend: bypass the login gate
+
+The `_auth` layout route (`frontend/src/routes/_auth.tsx`) redirects to `/login` when no token is found in localStorage. In no-auth mode we skip that redirect and return an empty string as the dummy token (the backend ignores the `Authorization` header entirely).
+
+Control is via a Vite env variable set at build time:
+
+```
+VITE_REQUIRE_AUTH=false
+```
+
+In `_auth.tsx`:
+
+```ts
+const REQUIRE_AUTH = import.meta.env.VITE_REQUIRE_AUTH !== "false";
+
+beforeLoad: ({ context, location }) => {
+  const token = context.token;
+  if (REQUIRE_AUTH && !token) {
+    throw redirect({ to: "/login", search: { redirect: location.href } });
+  }
+  return { token: token ?? "" };
+}
+```
+
+All child routes receive `token: string` as before, so no downstream API calls need to change. The empty-string token is sent in the `Authorization: Bearer ` header but the no-auth backend ignores it.
+
+---
+
+## Step 8 — CI
+
+Add a job that builds and tests with `--no-default-features` to catch regressions in the no-auth path:
+
+```yaml
+- name: Test (no-auth)
+  run: cargo test --no-default-features
+```
+
+---
+
+## File Change Summary (including frontend)
+
+| File | Change |
+|---|---|
+| `Cargo.toml` | Add `[features]` section |
+| `src/auth_gate.rs` | **New** — `MaybeAuth` extractor (cfg-gated impls) |
+| `src/lib.rs` | Add `pub mod auth_gate;` |
+| `src/app.rs` | Gate `auth` + `user` route registration with `#[cfg]` |
+| `src/controllers/recipes.rs` | Replace 8 `auth::JWT` params with `MaybeAuth` |
+| `src/controllers/ingredients.rs` | Replace 5 `auth::JWT` params with `MaybeAuth` |
+| `src/controllers/shoppinglists.rs` | Replace 15 `auth::JWT` params with `MaybeAuth` |
+| `src/controllers/mealplans.rs` | Replace 9 `auth::JWT` params with `MaybeAuth` |
+| `src/controllers/ailes.rs` | Replace 2 `auth::JWT` params with `MaybeAuth` |
+| `src/controllers/storage.rs` | Replace 1 `auth::JWT` param with `MaybeAuth` |
+| `src/controllers/graphql.rs` | Replace 1 `auth::JWT` param with `MaybeAuth` |
+| `tests/requests/prepare_data.rs` | Gate body of `authenticated()` with `#[cfg(feature = "require-auth")]` |
+| `tests/requests/user.rs` | Gate `can_get_current_user` test with `#[cfg(feature = "require-auth")]` |
+| `frontend/src/routes/_auth.tsx` | Gate redirect to `/login` behind `VITE_REQUIRE_AUTH !== "false"` |
+
+---
+
+## Pitfalls to Watch
+
+- **`UserClaims` construction**: Check the loco-rs source for all required fields. Look at `~/.cargo/registry/src/.../loco-rs-*/src/auth/jwt.rs`.
+- **Anonymous user must be seeded**: If `find_by_pid` returns `EntityNotFound`, every handler will error in no-auth mode even though auth is disabled.
+- **GraphQL user data**: The GraphQL resolvers access the user via `ctx.data_unchecked::<users::Model>()` — the anonymous user seed handles this. Verify no resolver panics if the user has no real data.

--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -20,13 +20,15 @@ export function Navbar() {
         <li>
           <NavLink name={"Recipes"} to={"/recipes"} />
         </li>
-        <li>
-          {token ? (
-            <UserOrLogin token={token} />
-          ) : (
-            <NavLink name={"Login"} to={"/login"} />
-          )}
-        </li>
+        {import.meta.env.VITE_REQUIRE_AUTH !== "false" && (
+          <li>
+            {token ? (
+              <UserOrLogin token={token} />
+            ) : (
+              <NavLink name={"Login"} to={"/login"} />
+            )}
+          </li>
+        )}
       </ul>
     </nav>
   );

--- a/frontend/src/routes/_auth.tsx
+++ b/frontend/src/routes/_auth.tsx
@@ -1,11 +1,14 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
+// Set VITE_REQUIRE_AUTH=false at build time to disable the login gate.
+const REQUIRE_AUTH = import.meta.env.VITE_REQUIRE_AUTH !== "false";
+
 export const Route = createFileRoute("/_auth")({
   // Before loading, authenticate the user via data in the query cache
   // This will also happen during prefetching (e.g. hovering over links, etc.)
   beforeLoad: ({ context, location }) => {
     const token = context.token;
-    if (!token) {
+    if (REQUIRE_AUTH && !token) {
       throw redirect({
         to: "/login",
         search: {
@@ -14,7 +17,7 @@ export const Route = createFileRoute("/_auth")({
       });
     }
     return {
-      token,
+      token: token ?? "",
     };
   },
 });

--- a/src/app.rs
+++ b/src/app.rs
@@ -204,23 +204,6 @@ impl Hooks for App {
 
         db::seed::<users::ActiveModel>(db, &base.join("users.yaml").display().to_string()).await?;
 
-        // In no-auth mode a single anonymous user must exist in the database so
-        // that the `find_by_pid` gate inside every handler succeeds.
-        #[cfg(not(feature = "require-auth"))]
-        {
-            use crate::auth_gate::ANONYMOUS_PID;
-            db.execute(Statement::from_string(
-                DbBackend::Postgres,
-                format!(
-                    "INSERT INTO users \
-                        (pid, email, password, api_key, name, created_at, updated_at) \
-                     VALUES \
-                        ('{ANONYMOUS_PID}', 'anonymous@foody.local', 'noop', 'lo-anonymous', 'Anonymous', NOW(), NOW()) \
-                     ON CONFLICT DO NOTHING"
-                ),
-            ))
-            .await?;
-        }
         for table in ["users"] {
             db.query_one(Statement::from_string(
                 DbBackend::Postgres,

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,16 +49,22 @@ impl Hooks for App {
     }
 
     fn routes(_ctx: &AppContext) -> AppRoutes {
-        AppRoutes::with_default_routes()
+        let routes = AppRoutes::with_default_routes()
             .add_route(controllers::storage::routes())
             .add_route(controllers::recipes::routes())
             .add_route(controllers::shoppinglists::routes())
             .add_route(controllers::ingredients::routes())
             .add_route(controllers::mealplans::routes())
             .add_route(controllers::ailes::routes())
+            .add_route(controllers::graphql::routes());
+
+        // Login and current-user endpoints are only meaningful when auth is required.
+        #[cfg(feature = "require-auth")]
+        let routes = routes
             .add_route(controllers::auth::routes())
-            .add_route(controllers::user::routes())
-            .add_route(controllers::graphql::routes())
+            .add_route(controllers::user::routes());
+
+        routes
     }
 
     async fn connect_workers(_ctx: &AppContext, _queue: &loco_rs::prelude::Queue) -> Result<()> {
@@ -197,6 +203,24 @@ impl Hooks for App {
         }
 
         db::seed::<users::ActiveModel>(db, &base.join("users.yaml").display().to_string()).await?;
+
+        // In no-auth mode a single anonymous user must exist in the database so
+        // that the `find_by_pid` gate inside every handler succeeds.
+        #[cfg(not(feature = "require-auth"))]
+        {
+            use crate::auth_gate::ANONYMOUS_PID;
+            db.execute(Statement::from_string(
+                DbBackend::Postgres,
+                format!(
+                    "INSERT INTO users \
+                        (pid, email, password, api_key, name, created_at, updated_at) \
+                     VALUES \
+                        ('{ANONYMOUS_PID}', 'anonymous@foody.local', 'noop', 'lo-anonymous', 'Anonymous', NOW(), NOW()) \
+                     ON CONFLICT DO NOTHING"
+                ),
+            ))
+            .await?;
+        }
         for table in ["users"] {
             db.query_one(Statement::from_string(
                 DbBackend::Postgres,

--- a/src/auth_gate.rs
+++ b/src/auth_gate.rs
@@ -1,0 +1,62 @@
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::request::Parts;
+use loco_rs::{app::AppContext, errors::Error};
+#[cfg(feature = "require-auth")]
+use loco_rs::prelude::auth;
+
+/// The PID used for the anonymous user when the `require-auth` feature is disabled.
+pub const ANONYMOUS_PID: &str = "00000000-0000-0000-0000-000000000000";
+
+/// A minimal claims struct exposing the user PID.
+///
+/// Mirrors the interface of `auth::jwt::UserClaims` (which has a private `exp`
+/// field and therefore cannot be constructed outside of loco-rs), so that all
+/// handler bodies can use `auth.claims.pid` unchanged regardless of whether the
+/// `require-auth` feature is active.
+pub struct Claims {
+    pub pid: String,
+}
+
+/// Axum extractor that enforces JWT authentication when the `require-auth`
+/// feature is enabled, and becomes a no-op (always succeeds with the anonymous
+/// PID) when the feature is disabled.
+///
+/// Use `MaybeAuth` in place of `auth::JWT` in every handler signature.
+pub struct MaybeAuth {
+    pub claims: Claims,
+}
+
+#[cfg(feature = "require-auth")]
+impl<S> FromRequestParts<S> for MaybeAuth
+where
+    AppContext: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Error> {
+        let jwt = auth::JWT::from_request_parts(parts, state).await?;
+        Ok(Self {
+            claims: Claims {
+                pid: jwt.claims.pid,
+            },
+        })
+    }
+}
+
+#[cfg(not(feature = "require-auth"))]
+impl<S> FromRequestParts<S> for MaybeAuth
+where
+    AppContext: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(_parts: &mut Parts, _state: &S) -> Result<Self, Error> {
+        Ok(Self {
+            claims: Claims {
+                pid: ANONYMOUS_PID.to_string(),
+            },
+        })
+    }
+}

--- a/src/auth_gate.rs
+++ b/src/auth_gate.rs
@@ -1,8 +1,8 @@
 use axum::extract::{FromRef, FromRequestParts};
 use axum::http::request::Parts;
-use loco_rs::{app::AppContext, errors::Error};
 #[cfg(feature = "require-auth")]
 use loco_rs::prelude::auth;
+use loco_rs::{app::AppContext, errors::Error};
 
 /// The PID used for the anonymous user when the `require-auth` feature is disabled.
 pub const ANONYMOUS_PID: &str = "00000000-0000-0000-0000-000000000000";

--- a/src/controllers/ailes.rs
+++ b/src/controllers/ailes.rs
@@ -6,6 +6,7 @@ use loco_rs::prelude::*;
 use sea_orm::{QueryOrder, QuerySelect};
 use serde::{Deserialize, Serialize};
 
+use crate::auth_gate::MaybeAuth;
 use crate::models::{_entities::aisles, users};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -20,7 +21,7 @@ struct AislesResponse {
     aisles: Vec<FullAisleResponse>,
 }
 
-pub async fn all_ailes(auth: auth::JWT, State(ctx): State<AppContext>) -> Result<Response> {
+pub async fn all_ailes(auth: MaybeAuth, State(ctx): State<AppContext>) -> Result<Response> {
     let _user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
 
     let ailes = aisles::Entity::find().all(&ctx.db).await?;
@@ -43,7 +44,7 @@ pub struct NewAisle {
 }
 
 pub async fn create_aisle(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     extract::Json(params): extract::Json<NewAisle>,
 ) -> Result<Response> {

--- a/src/controllers/graphql.rs
+++ b/src/controllers/graphql.rs
@@ -2,6 +2,7 @@ use axum::{body::Body, extract::State, http::Request, routing::post};
 use loco_rs::{app::AppContext, prelude::*};
 
 use crate::{
+    auth_gate::MaybeAuth,
     graphql::{self},
     models::users::{self},
 };
@@ -11,7 +12,7 @@ pub fn routes() -> Routes {
 }
 
 pub async fn gql_handler(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     req: Request<Body>,
 ) -> Result<Response> {

--- a/src/controllers/ingredients.rs
+++ b/src/controllers/ingredients.rs
@@ -18,6 +18,7 @@ use crate::models::{
 };
 
 use super::TagsResponse;
+use crate::auth_gate::MaybeAuth;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AisleResponse {
@@ -69,7 +70,7 @@ impl From<(Ingredient, Option<AisleRef>, Option<Storage>)> for IngredientRespons
     }
 }
 
-pub async fn index(auth: auth::JWT, State(ctx): State<AppContext>) -> Result<Response> {
+pub async fn index(auth: MaybeAuth, State(ctx): State<AppContext>) -> Result<Response> {
     // check auth
     let _user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
 
@@ -95,7 +96,7 @@ pub struct NewIngredient {
 }
 
 pub async fn create(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     extract::Json(params): extract::Json<NewIngredient>,
 ) -> Result<Response> {
@@ -144,7 +145,7 @@ struct MergeIngredientsParams {
 }
 
 async fn merge_ingredients(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     extract::Json(params): extract::Json<MergeIngredientsParams>,
 ) -> Result<StatusCode> {
@@ -183,7 +184,7 @@ async fn merge_ingredients(
 }
 
 pub async fn all_ingredients_tags(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
 ) -> Result<Response> {
     let _user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
@@ -222,7 +223,7 @@ pub struct EditIngredientParams {
 }
 
 pub async fn edit(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     Path(id): Path<i32>,
     State(ctx): State<AppContext>,
     extract::Json(params): extract::Json<EditIngredientParams>,

--- a/src/controllers/mealplans.rs
+++ b/src/controllers/mealplans.rs
@@ -5,6 +5,7 @@ use axum::{
 use loco_rs::prelude::*;
 use serde::{Deserialize, Serialize};
 
+use crate::auth_gate::MaybeAuth;
 use crate::models::{
     _entities::{
         ingredients_in_recipes, ingredients_in_shoppinglists, meal_plans, meals_in_meal_plans,
@@ -95,7 +96,7 @@ where
     }
 }
 
-pub async fn all_mealplans(auth: auth::JWT, State(ctx): State<AppContext>) -> Result<Response> {
+pub async fn all_mealplans(auth: MaybeAuth, State(ctx): State<AppContext>) -> Result<Response> {
     let _user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
 
     let plans = meal_plans::Entity::find()
@@ -113,7 +114,7 @@ pub struct NewMealPlan {
 }
 
 pub async fn create_meal_plan(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     extract::Json(params): extract::Json<NewMealPlan>,
 ) -> Result<Response> {
@@ -181,7 +182,7 @@ pub struct AddMealParams {
 }
 
 pub async fn add_to_meal(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path(id): Path<i32>,
     extract::Json(meal): extract::Json<AddMealParams>,
@@ -223,7 +224,7 @@ pub struct MarkMealAsCookedParams {
 }
 
 pub async fn mark_meal_as_cooked(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path((id, meal_id)): Path<(i32, i32)>,
     extract::Json(mark): extract::Json<MarkMealAsCookedParams>,
@@ -248,7 +249,7 @@ pub async fn mark_meal_as_cooked(
 }
 
 pub async fn delete_meal_from_mealplan(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path((id, meal_id)): Path<(i32, i32)>,
 ) -> Result<()> {
@@ -272,7 +273,7 @@ pub struct SetMealOfSectionParams {
 }
 
 pub async fn set_section_of_meal(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path((id, meal_id)): Path<(i32, i32)>,
     extract::Json(SetMealOfSectionParams { section }): extract::Json<SetMealOfSectionParams>,
@@ -298,7 +299,7 @@ pub async fn set_section_of_meal(
 
 // TODO this is more of an interim thing anyway...
 pub async fn clear_meal_plan(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path(id): Path<i32>,
 ) -> Result<()> {
@@ -319,7 +320,7 @@ pub async fn clear_meal_plan(
 
 // TODO this is more of an interim thing anyway...
 pub async fn remove_meal_plan(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path(id): Path<i32>,
 ) -> Result<()> {
@@ -345,7 +346,7 @@ pub struct AddMealPlanToShoppinglistsParams {
 // TODO: Make this simpler...
 #[allow(clippy::cognitive_complexity)]
 pub async fn add_meal_plan_to_shoppinglist(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path(id): Path<i32>,
     extract::Json(AddMealPlanToShoppinglistsParams {

--- a/src/controllers/recipes.rs
+++ b/src/controllers/recipes.rs
@@ -15,6 +15,7 @@ use crate::models::{
 use super::ingredients::{AisleResponse, IngredientResponse};
 use super::shoppinglists::QuantityResponse;
 use super::TagsResponse;
+use crate::auth_gate::MaybeAuth;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RecipesResponse {
@@ -42,7 +43,7 @@ pub struct IngredientWithQuantityResponse {
     quantity: Vec<QuantityResponse>,
 }
 
-pub async fn all_recipes(auth: auth::JWT, State(ctx): State<AppContext>) -> Result<Response> {
+pub async fn all_recipes(auth: MaybeAuth, State(ctx): State<AppContext>) -> Result<Response> {
     // check auth
     let _user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
 
@@ -87,7 +88,7 @@ pub async fn all_recipes(auth: auth::JWT, State(ctx): State<AppContext>) -> Resu
 }
 
 pub async fn recipe(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     Path(id): Path<i32>,
     State(ctx): State<AppContext>,
 ) -> Result<Response> {
@@ -136,7 +137,7 @@ pub async fn recipe(
 }
 
 pub async fn delete_recipe(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     Path(recipe_id): Path<i32>,
     State(ctx): State<AppContext>,
 ) -> Result<()> {
@@ -227,7 +228,7 @@ pub struct CreateRecipe {
 }
 
 pub async fn create_recipe(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     extract::Json(params): extract::Json<CreateRecipe>,
 ) -> Result<Response> {
@@ -317,7 +318,7 @@ pub async fn create_recipe(
     })
 }
 
-pub async fn all_recipe_tags(auth: auth::JWT, State(ctx): State<AppContext>) -> Result<Response> {
+pub async fn all_recipe_tags(auth: MaybeAuth, State(ctx): State<AppContext>) -> Result<Response> {
     let _user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
 
     let db = ctx.db;
@@ -347,7 +348,7 @@ pub struct AddIngredientParams {
 }
 
 pub async fn add_ingredient(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     Path(id): Path<i32>,
     State(ctx): State<AppContext>,
     extract::Json(params): extract::Json<AddIngredientParams>,
@@ -414,7 +415,7 @@ pub struct EditRecipeParameters {
 }
 
 pub async fn edit_recipe(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     Path(id): Path<i32>,
     State(ctx): State<AppContext>,
     extract::Json(params): extract::Json<EditRecipeParameters>,
@@ -537,7 +538,7 @@ pub async fn edit_recipe(
 }
 
 pub async fn delete_ingredient(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path((id, ingredient)): Path<(i32, i32)>,
 ) -> Result<()> {

--- a/src/controllers/shoppinglists.rs
+++ b/src/controllers/shoppinglists.rs
@@ -15,6 +15,7 @@ use crate::models::shoppinglists::{self, FullShoppinglist, Item, Shoppinglist};
 use crate::models::users;
 
 use super::ingredients::IngredientResponse;
+use crate::auth_gate::MaybeAuth;
 
 #[derive(Serialize)]
 pub struct ShoppinglistsResponse {
@@ -92,7 +93,7 @@ impl From<Shoppinglist> for ShoppinglistResponse {
     }
 }
 
-pub async fn all_shoppinglists(auth: auth::JWT, State(ctx): State<AppContext>) -> Result<Response> {
+pub async fn all_shoppinglists(auth: MaybeAuth, State(ctx): State<AppContext>) -> Result<Response> {
     // check auth
     let _user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
 
@@ -112,7 +113,7 @@ pub struct NewShoppinglist {
 }
 
 pub async fn create_shoppinglist(
-    _auth: auth::JWT,
+    _auth: MaybeAuth,
     State(ctx): State<AppContext>,
     extract::Json(params): extract::Json<NewShoppinglist>,
 ) -> Result<Response> {
@@ -140,7 +141,7 @@ pub struct NewQuantity {
 }
 
 pub async fn add_ingredient(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path(id): Path<i32>,
     extract::Json(params): extract::Json<NewIngredient>,
@@ -204,7 +205,7 @@ pub struct RemoveIngredient {
 }
 
 pub async fn remove_ingredient(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path(id): Path<i32>,
     extract::Json(params): extract::Json<RemoveIngredient>,
@@ -235,7 +236,7 @@ pub async fn remove_ingredient(
 }
 
 pub async fn remove_shoppinglist(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     Path(id): Path<i32>,
     State(ctx): State<AppContext>,
 ) -> Result<()> {
@@ -249,7 +250,7 @@ pub async fn remove_shoppinglist(
 }
 
 pub async fn shoppinglist(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     Path(id): Path<u32>,
     State(ctx): State<AppContext>,
 ) -> Result<Response> {
@@ -301,7 +302,7 @@ pub struct InBasketPayload {
 }
 
 pub async fn toggle_in_basket_for_item(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path((id, ingredient_id)): Path<(u32, u32)>,
     extract::Json(params): extract::Json<InBasketPayload>,
@@ -330,7 +331,7 @@ pub struct NoteOnItem {
 }
 
 pub async fn add_note_to_item(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path((id, ingredient_id)): Path<(u32, u32)>,
     extract::Json(params): extract::Json<NoteOnItem>,
@@ -354,7 +355,7 @@ pub async fn add_note_to_item(
 }
 
 pub async fn add_recipe_to_shoppinglist(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path((shoppinglist_id, recipe_id)): Path<(i32, i32)>,
 ) -> Result<()> {
@@ -403,7 +404,7 @@ pub async fn add_recipe_to_shoppinglist(
 }
 
 pub async fn remove_recipe_from_shoppinglist(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path((shoppinglist_id, recipe_id)): Path<(i32, i32)>,
 ) -> Result<()> {
@@ -428,7 +429,7 @@ pub struct RawQuantity {
 }
 
 pub async fn add_quantity_to_ingredient(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path((id, ingredient_id)): Path<(i32, i32)>,
     extract::Json(params): extract::Json<RawQuantity>,
@@ -454,7 +455,7 @@ pub async fn add_quantity_to_ingredient(
 }
 
 pub async fn remove_quantity_from_shoppinglist(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path((id, quantity_id)): Path<(i32, i32)>,
 ) -> Result<()> {
@@ -482,7 +483,7 @@ pub async fn remove_quantity_from_shoppinglist(
 }
 
 pub async fn update_quantity_on_shoppinglist(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path((id, quantity_id)): Path<(i32, i32)>,
 
@@ -532,7 +533,7 @@ pub async fn update_quantity_on_shoppinglist(
 }
 
 pub async fn clear_checked_shoppinglist_items(
-    auth: auth::JWT,
+    auth: MaybeAuth,
     State(ctx): State<AppContext>,
     Path(id): Path<i32>,
 ) -> Result<()> {

--- a/src/controllers/storage.rs
+++ b/src/controllers/storage.rs
@@ -3,6 +3,7 @@ use loco_rs::prelude::*;
 use serde::Serialize;
 
 use crate::{
+    auth_gate::MaybeAuth,
     controllers::ingredients::StorageResponse,
     models::{storages, users},
 };
@@ -13,7 +14,7 @@ pub struct ListStorageResponse {
 }
 
 #[debug_handler]
-pub async fn index(auth: auth::JWT, State(ctx): State<AppContext>) -> Result<Response> {
+pub async fn index(auth: MaybeAuth, State(ctx): State<AppContext>) -> Result<Response> {
     let _user = users::Model::find_by_pid(&ctx.db, &auth.claims.pid).await?;
 
     let storage_locations = storages::Entity::find().all(&ctx.db).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod auth_gate;
 pub mod controllers;
 pub mod graphql;
 pub mod mailers;

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -124,7 +124,27 @@ impl super::_entities::users::Model {
     /// # Errors
     ///
     /// When could not find user  or DB query error
+    #[cfg_attr(not(feature = "require-auth"), allow(unreachable_code))]
     pub async fn find_by_pid(db: &DatabaseConnection, pid: &str) -> ModelResult<Self> {
+        #[cfg(not(feature = "require-auth"))]
+        {
+            let _ = (db, pid);
+            return Ok(Self {
+                id: 0,
+                pid: Uuid::nil(),
+                email: String::new(),
+                password: String::new(),
+                api_key: String::new(),
+                name: String::new(),
+                created_at: Default::default(),
+                updated_at: Default::default(),
+                reset_token: None,
+                reset_sent_at: None,
+                email_verification_token: None,
+                email_verification_sent_at: None,
+                email_verified_at: None,
+            });
+        }
         let parse_uuid = Uuid::parse_str(pid).map_err(|e| ModelError::Any(e.into()))?;
         let user = users::Entity::find()
             .filter(users::Column::Pid.eq(parse_uuid))

--- a/tests/requests/prepare_data.rs
+++ b/tests/requests/prepare_data.rs
@@ -19,26 +19,10 @@ pub async fn authenticated(request: &mut TestServer, ctx: &AppContext) {
         request.add_header(auth_key, auth_value);
     }
 
-    // In no-auth mode no token is needed, but handlers still call find_by_pid,
-    // so we ensure the anonymous user row exists in the test database.
+    // In no-auth mode, find_by_pid short-circuits before hitting the DB,
+    // so no anonymous user row is needed.
     #[cfg(not(feature = "require-auth"))]
-    {
-        use foody::auth_gate::ANONYMOUS_PID;
-        use sea_orm::{ConnectionTrait, DbBackend, Statement};
-        ctx.db
-            .execute(Statement::from_string(
-                DbBackend::Postgres,
-                format!(
-                    "INSERT INTO users \
-                        (pid, email, password, api_key, name, created_at, updated_at) \
-                     VALUES \
-                        ('{ANONYMOUS_PID}', 'anonymous@foody.local', 'noop', 'lo-anonymous', 'Anonymous', NOW(), NOW()) \
-                     ON CONFLICT DO NOTHING"
-                ),
-            ))
-            .await
-            .expect("failed to create anonymous user");
-    }
+    let _ = ctx;
 }
 
 pub async fn init_user_login(request: &TestServer, ctx: &AppContext) -> LoggedInUser {

--- a/tests/requests/prepare_data.rs
+++ b/tests/requests/prepare_data.rs
@@ -12,11 +12,33 @@ pub struct LoggedInUser {
 }
 
 pub async fn authenticated(request: &mut TestServer, ctx: &AppContext) {
-    let logged_in_user = init_user_login(request, ctx).await;
+    #[cfg(feature = "require-auth")]
+    {
+        let logged_in_user = init_user_login(request, ctx).await;
+        let (auth_key, auth_value) = auth_header(&logged_in_user.token);
+        request.add_header(auth_key, auth_value);
+    }
 
-    let (auth_key, auth_value) = auth_header(&logged_in_user.token);
-
-    request.add_header(auth_key, auth_value)
+    // In no-auth mode no token is needed, but handlers still call find_by_pid,
+    // so we ensure the anonymous user row exists in the test database.
+    #[cfg(not(feature = "require-auth"))]
+    {
+        use foody::auth_gate::ANONYMOUS_PID;
+        use sea_orm::{ConnectionTrait, DbBackend, Statement};
+        ctx.db
+            .execute(Statement::from_string(
+                DbBackend::Postgres,
+                format!(
+                    "INSERT INTO users \
+                        (pid, email, password, api_key, name, created_at, updated_at) \
+                     VALUES \
+                        ('{ANONYMOUS_PID}', 'anonymous@foody.local', 'noop', 'lo-anonymous', 'Anonymous', NOW(), NOW()) \
+                     ON CONFLICT DO NOTHING"
+                ),
+            ))
+            .await
+            .expect("failed to create anonymous user");
+    }
 }
 
 pub async fn init_user_login(request: &TestServer, ctx: &AppContext) -> LoggedInUser {

--- a/tests/requests/user.rs
+++ b/tests/requests/user.rs
@@ -16,6 +16,7 @@ macro_rules! configure_insta {
     };
 }
 
+#[cfg(feature = "require-auth")]
 #[tokio::test]
 #[serial]
 async fn can_get_current_user() {


### PR DESCRIPTION
Introduces a `MaybeAuth` Axum extractor in `src/auth_gate.rs` that enforces JWT auth when the `require-auth` feature is enabled (the default) and becomes a no-op when disabled. `find_by_pid` short-circuits in no-auth mode so no anonymous user needs to be seeded. The frontend login gate and navbar login link are controlled by `VITE_REQUIRE_AUTH=false` at build time.